### PR TITLE
[update] ココフォリア v1.29.4で表示崩れていたのに対応

### DIFF
--- a/status/ccfolayer-status-001.css
+++ b/status/ccfolayer-status-001.css
@@ -9,7 +9,7 @@
     --avatar-border-style: solid;
     --avatar-border-color: rgb(245, 245, 245);
     --avatar-border-radius: 10px;
-  
+
     --badge-height:24px;
     --badge-width: 40px;
     --badge-background: rgba(0, 0, 0, 0.64);
@@ -90,4 +90,21 @@
 .hvcSCS img {
   max-width: 60%;
   flex-shrink: 0;
+}
+
+/* 画像の下部にステータスを移動 */
+.csWTEe {
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* 画像の左右に余白を */
+.fHePpg {
+  padding: 0px 16px;
+}
+
+/* ステータス集団の左余白消す */
+.ScykT {
+  margin-left: 0;
+  gap: 20px;
 }

--- a/status/ccfolayer-status-001.css
+++ b/status/ccfolayer-status-001.css
@@ -76,31 +76,27 @@
   height: 28px;
 }
 
-.hvcSCS {
-  display: flex;
-  flex-direction: column;
-  min-height: var(--avatar-height);
-  width: var(--avatar-width);
-}
-.hvcSCS::before {
-  flex-shrink: 1;
-  flex-grow: 1;
-  content: "";
-}
-.hvcSCS img {
-  max-width: 60%;
-  flex-shrink: 0;
-}
-
 /* 画像の下部にステータスを移動 */
 .csWTEe {
   flex-direction: column;
   gap: 24px;
 }
 
-/* 画像の左右に余白を */
+/* 画像のところ */
 .fHePpg {
-  padding: 0px 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: var(--avatar-height);
+  width: var(--avatar-width);
+}
+.fHePpg::before {
+  flex-shrink: 1;
+  flex-grow: 1;
+  content: "";
+}
+.fHePpg img {
+  max-width: 60%;
+  flex-shrink: 0;
 }
 
 /* ステータス集団の左余白消す */


### PR DESCRIPTION
# [update] ココフォリア v1.29.4で表示崩れていたのに対応

| before | after |
| --- | --- |
| ![Screenshot 2024-04-10 03-39-55](https://github.com/kaigemap/ccfolayer/assets/12152903/aa7daa07-650d-4465-9b00-1e7f2a350755) | ![Screenshot 2024-04-10 03-45-10](https://github.com/kaigemap/ccfolayer/assets/12152903/55f16e02-f9bc-4185-bad5-88e5ccf8237d) |
